### PR TITLE
DNA-180 Fix wordpress connectivity dropoff

### DIFF
--- a/forms/core/Ajax.php
+++ b/forms/core/Ajax.php
@@ -40,8 +40,9 @@ abstract class Ajax
 
 	public static function ajax_handler()
 	{
+		Application::refreshTokenIfNeeded();
 		// we could further optimize the plugin with one entry point for all ajax requests
-
+		
 		$response = new \stdClass();
 
 		$requestType = Request::getPost( 'type' );
@@ -104,7 +105,7 @@ abstract class Ajax
 	// non authenticated users
 	public static function ajaxFormHandler()
 	{
-
+		Application::refreshTokenIfNeeded();
 
 		$response = new \stdClass();
 
@@ -235,7 +236,6 @@ abstract class Ajax
 		);
 
 		$CampaignMonitor = Application::$CampaignMonitor;
-		$x = $CampaignMonitor->get_clients();
 		$addedEmailAddress = $CampaignMonitor->add_subscriber( $listId, $dataAr );
 
 		$error = $CampaignMonitor->get_last_error();

--- a/forms/core/Application.php
+++ b/forms/core/Application.php
@@ -1410,19 +1410,22 @@ class Application
 			if (isset($newCredentials->error)) {
 				// TODO: add some kind of error-handling if API returns error
 				// For now just clear out the tokens
-				Settings::add('access_token', '');
-				Settings::add('refresh_token', '');
-				Settings::add('expiry', '');
+				Application::updateTokens('', '', 0);
 				return false;
 			}
 
-			Settings::add('access_token',$newCredentials->access_token);
-			Settings::add('refresh_token',$newCredentials->refresh_token);
-			Settings::add('expiry', time() + $newCredentials->expires_in);
-
+            Application::updateTokens($newCredentials->access_token, $newCredentials->refresh_token, time() + $newCredentials->expires_in);
 			return true;
 		}
 
 		return false;
-	}
+    }
+    
+    public static function updateTokens($accessToken, $refreshToken, $expiry) {
+        Settings::add('access_token', $accessToken);
+        Settings::add('refresh_token', $refreshToken);
+        Settings::add('expiry', $expiry);
+
+        Application::$CampaignMonitor->update_tokens($accessToken, $refreshToken);
+    }
 }

--- a/forms/core/Application.php
+++ b/forms/core/Application.php
@@ -166,6 +166,7 @@ class Application
                         $appSettings = Settings::get();
                         // we are connected
                         Options::update('connected', TRUE );
+                        CampaignMonitor::update_tokens($credentials->access_token, $credentials->refresh_token);
                         unset($_GET['code']);
                     }
                 }
@@ -243,8 +244,8 @@ class Application
         )
          */
         $globalOptions = get_option('campaign_monitor_settings');
-
-
+        
+        // TODO: Clean up this and replace update.php with new instructions
         // if the old plugin is installed grab old forms and convert it to to the new format
         if( $existElementTable === $elementsTable && $existAbTestTable === $abTestTable ) {
 
@@ -263,11 +264,8 @@ class Application
             $formTypeMap['button'] = FormType::BUTTON;
             $formTypeMap['simple_form'] = FormType::EMBEDDED;
 
-            $clients = Application::$CampaignMonitor->get_clients();
-            if (isset($clients->error)) {
-                // TODO: handle error when it gets to this point
-                return;
-            }
+            $clients = array(); // set as empty as code is broken anyway
+            
             $activeClients = array();
 
             foreach ($clients as $client) {
@@ -594,7 +592,7 @@ class Application
             Settings::add( 'campaign_monitor_clients', $clients );
 
 	        if (!empty($clients)) {
-		        if (is_array($clients)) {
+		        if (\is_array($clients)) {
 			        if (count($clients) === 1 && !empty($clients[0])) {
 				        $CID = $clients[0]->ClientID;
 				        Settings::add( 'default_client', $CID );

--- a/forms/core/Application.php
+++ b/forms/core/Application.php
@@ -3,13 +3,9 @@
 namespace forms\core;
 
 
-
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
-
-
-
 
 class Application
 {
@@ -56,7 +52,6 @@ class Application
 
     public static function doUpdate() {
         if (Application::isConnected()) {
-
             $pluginUpdate = self::UpdateStatus();
             $updatePage = Request::get('page');
             if (!$pluginUpdate && $updatePage !== 'campaign_monitor_update_page') {
@@ -69,7 +64,6 @@ class Application
 
     public static function authenticate()
     {
-
         $error = Request::get( 'error' );
         $queriedPage = Request::get( 'page' );
 
@@ -119,98 +113,63 @@ class Application
             }
         }
 
-
-        // do I have an authorization token
         $authorizationToken = Settings::get('access_token');
 
+        if (!empty($error)) {
+            $description = Request::get('error_description');
 
-        if (!empty($authorizationToken)){
-            // we are authorize
-            // check if refresh token is still good
-            $timeTillExpire = Settings::get('expiry') - time();
-            if ($timeTillExpire <  (60*60*24))
-            {
-                $auth = array(
-                    'access_token' => Settings::get('access_token'),
-                    'refresh_token' => Settings::get('refresh_token')
-                );
+            $html = '<div class="wrap">';
+            $html .= '<h1>Campaign Monitor</h1>';
+            $html .= '<div  id="error" class="error">';
+            $html .= $error;
+            $html .= '</div><!-- end error-->';
+            $html .= '</div><!-- end wrap-->';
 
-                list($new_access_token, $new_expires_in, $new_refresh_token) = Application::$CampaignMonitor->refresh_token($auth);
-
-                Settings::add('access_token',$new_access_token);
-                Settings::add('refresh_token',$new_refresh_token);
-                // add current time
-                // convert number of seconds to  a unix timestamp
-                Settings::add('expiry', time() + $new_expires_in);
-            }
-
+            echo $html;
+            exit;
         } else {
+            // initial connect
+            $appSettings  = Settings::get();
+            $redirectUrl = Helper::getRedirectUrl();
+            $code = Request::get( 'code' );
 
-            if (!empty($error)){
-                $description = Request::get('error_description');
-                // there was something wrong
-                $html = '<div class="wrap">';
-                $html .= '<h1>Campaign Monitor</h1>';
-                $html .= '<div  id="error" class="error">';
-                $html .= $error;
-                $html .= '</div><!-- end error-->';
-                $html .= '</div><!-- end wrap-->';
+            if (!empty($code)) {
+                Options::update('code', $code);
+                $params = array('grant_type' => urlencode('authorization_code'),
+                    'client_id' => urlencode($appSettings['client_id']),
+                    'client_secret' => urlencode($appSettings['client_secret']),
+                    'code' => $code,
+                    'redirect_uri' =>  $redirectUrl);
 
-                echo $html;
-                exit;
+                $postUrl = Connect::getTransport('oauth/token', $params);
+                $endpoint = 'https://api.createsend.com/oauth/token';
+                $results =  Connect::request($params,$endpoint);
 
-            }else {
-                $appSettings  = Settings::get();
-                $redirectUrl = Helper::getRedirectUrl();
-                $code = Request::get( 'code' );
+                // Let's authenticate the user
+                if (!empty($results)) {
+                    $credentials = json_decode($results);
 
+                    if (isset($credentials->error)) {
+                        Settings::add('client_secret', '');
+                        Settings::add('client_id', '');
+                        $postError['title'] = $credentials->error;
+                        $postError['description'] = $credentials->error_description;
 
-                if (!empty($code)){
+                        // add this options so they can be access later
+                        Options::add('post_errors', $postError);
 
-                    Options::update('code', $code);
-                    $params = array('grant_type' => urlencode('authorization_code'),
-                        'client_id' => urlencode($appSettings['client_id']),
-                        'client_secret' => urlencode($appSettings['client_secret']),
-                        'code' => $code,
-                        'redirect_uri' =>  $redirectUrl);
-
-                    $postUrl = Connect::getTransport('oauth/token', $params);
-                    $endpoint = 'https://api.createsend.com/oauth/token';
-                    $results =  Connect::request($params,$endpoint);
-
-
-                    // Let's authenticate the user
-                    if (!empty($results)){
-                        $credentials = json_decode($results);
-
-
-                        if (isset($credentials->error)){
-
-
-                            Settings::add('client_secret', '');
-                            Settings::add('client_id', '');
-                            $postError['title'] = $credentials->error;
-                            $postError['description'] = $credentials->error_description;
-
-                            // add this options so they can be access later
-                            Options::add('post_errors', $postError);
-
-                            $settingsPage = get_admin_url() . 'admin.php?page=campaign_monitor_settings_page';
-                            \wp_redirect( $settingsPage );
-                            exit();
-
-                        } else {
-                            Settings::add('access_token', $credentials->access_token);
-                            Settings::add('refresh_token', $credentials->refresh_token);
-                            Settings::add('expiry', $credentials->expires_in);
-                            $appSettings = Settings::get();
-                            // we are connected
-                            Options::update('connected', TRUE );
-                            unset($_GET['code']);
-                        }
-
+                        $settingsPage = get_admin_url() . 'admin.php?page=campaign_monitor_settings_page';
+                        \wp_redirect( $settingsPage );
+                        exit();
+                    } else {
+                        Settings::add('access_token', $credentials->access_token);
+                        Settings::add('refresh_token', $credentials->refresh_token);
+                        Settings::add('expiry', time() + $credentials->expires_in);
+                        $appSettings = Settings::get();
+                        // we are connected
+                        Options::update('connected', TRUE );
+                        unset($_GET['code']);
                     }
-
                 }
             }
         }
@@ -233,8 +192,6 @@ class Application
 
     public static function run()
     {
-
-
         $logPath = Config::getRoot() .  'var' . DIRECTORY_SEPARATOR . 'log';
         Log::setDirectoryName( $logPath );
         $debug = Settings::get( 'debug' );
@@ -244,14 +201,15 @@ class Application
             ini_set( 'error_log', Log::getFileName() );
         }
 
-
         $accessToken = Settings::get('access_token');
         $refreshToken = Settings::get('refresh_token');
         self::$CampaignMonitor = new CampaignMonitor($accessToken, $refreshToken);
 
-	    if ( ! Application::isConnected() ) {
+	    if (!Application::isConnected()) {
 		    Application::authenticate();
-	    }
+	    } else {
+            Application::refreshTokenIfNeeded();
+        }
 
         // install app
         Application::init();
@@ -260,8 +218,6 @@ class Application
 
         // Listen for ajax requests
         Ajax::run();
-
-
     }
 
 
@@ -270,8 +226,6 @@ class Application
         $updateView = new View();
         $updateView->render( 'update' );
     }
-
-
 
     public static function update()
     {
@@ -312,6 +266,10 @@ class Application
             $formTypeMap['simple_form'] = FormType::EMBEDDED;
 
             $clients = Application::$CampaignMonitor->get_clients();
+            if (isset($clients->error)) {
+                // TODO: handle error when it gets to this point
+                return;
+            }
             $activeClients = array();
 
             foreach ($clients as $client) {
@@ -619,23 +577,16 @@ class Application
         Options::update( 'plugin_update', 2.0 );
     }
 
-
-
     public static function generateSettingsPage(){
-        // Application::authenticate();
-
         $settingsView = new View();
         $settingsView->render( 'settings' );
     }
 
     public static function generateConnectPage()
     {
-
-
         $appSettings = Settings::get();
 
-
-        if (is_array( $appSettings ) && array_key_exists( 'client_secret', $appSettings ) && !empty( $appSettings['client_secret'] ) && Application::isConnected()  ) {
+        if (is_array( $appSettings ) && array_key_exists( 'client_secret', $appSettings ) && !empty( $appSettings['client_secret'] ) && Application::isConnected()) {
             $appSettings = (object)$appSettings;
             $auth = array( 'access_token' => $appSettings->access_token,
                 'refresh_token' => $appSettings->refresh_token );
@@ -644,35 +595,38 @@ class Application
             $clients = Application::$CampaignMonitor->get_clients( $auth );
             Settings::add( 'campaign_monitor_clients', $clients );
 
-	        if ( ! empty( $clients ) ) {
-		        if ( \is_array( $clients ) ) {
-			        if (count( $clients ) === 1 && !empty($clients[0])) {
+	        if (!empty($clients)) {
+		        if (is_array($clients)) {
+			        if (count($clients) === 1 && !empty($clients[0])) {
 				        $CID = $clients[0]->ClientID;
 				        Settings::add( 'default_client', $CID );
 			        }
 		        } else {
-
-			        if ( ! empty( $clients->Message ) && strpos($clients->Message, 'Authorization') !== false ) {
-				        $message = 'To refresh your credentials please click on the "Disconnect Account" button';
-				        $message .= ' and then follow the on screen instruction to re-connect again!';
-				        $message = \urlencode( $message );
-			            ?>
-                        <div class="update-nag error is-dismissible notice">
-                            <p>
-                                There seems to be a problem with your credentials please disconnect and reconnect your account on the
-                                <a href="<?php echo  get_admin_url() . '/admin.php?page=campaign_monitor_settings_page&notice[description]='.filter_var($message,FILTER_SANITIZE_STRING).'&notice[title]=Notice!' ?>"> Campaign Monitor Settings </a> page
-                            </p>
-                        </div>
-                        <?php
+			        if (isset($clients->error)) {
+				        Application::generateConnectionErrorMessage();
 			        }
                 }
 	        }
-
+        } else if (Application::isConnected() && empty( $appSettings['client_secret'] )) {
+            Application::generateConnectionErrorMessage();
         }
-
 
         $connectView = new View();
         $connectView->render( 'connect' );
+    }
+
+    public static function generateConnectionErrorMessage() {
+        $message = 'To refresh your credentials please click on the "Disconnect Account" button';
+        $message .= ' and then follow the on screen instruction to re-connect again!';
+        $message = \urlencode( $message );
+        ?>
+        <div class="update-nag error is-dismissible notice">
+            <p>
+                There seems to be a problem with your credentials please disconnect and reconnect your account on the
+                <a href="<?php echo  get_admin_url() . '/admin.php?page=campaign_monitor_settings_page&notice[description]='.filter_var($message,FILTER_SANITIZE_STRING).'&notice[title]=Notice!' ?>"> Campaign Monitor Settings </a> page
+            </p>
+        </div>
+        <?php
     }
 
     public static function generateNewFormPage(){
@@ -688,17 +642,7 @@ class Application
         $createView->render( 'create' );
     }
 
-    public static function createAbTest()
-    {
-
-    }
-
-
-    public static function generateFormBuilder(){
-
-
-        // Application::authenticate();
-
+    public static function generateFormBuilder() {
         $appSettings  = Settings::get();
         $clientId = Settings::get( 'default_client' );
 
@@ -763,8 +707,6 @@ class Application
 
         $createView->setForm( $form );
         $createView->render( 'builder' );
-
-
     }
 
     protected static function UpdateStatus()
@@ -789,7 +731,6 @@ class Application
 
     }
 
-
     protected static function init()
     {
 
@@ -801,8 +742,6 @@ class Application
         add_action('admin_enqueue_scripts', array(__CLASS__, 'loadAdminScripts'), 10);
         if (!is_admin()) {
             add_action('wp_enqueue_scripts', array(__CLASS__, 'loadPublicScripts'));
-
-
         }
         add_action('admin_post_handle_cm_form_request', array(__CLASS__, 'handleRequest'));
         add_action('admin_post_nopriv', array(__CLASS__, 'handleRequest'));
@@ -827,13 +766,10 @@ class Application
             'media-views',
         );
 
-
         if (!empty($screen) && $screen->id === 'admin_page_campaign_monitor_create_builder') {
             $wp_scripts->queue = array(Helper::tokenize('ajax-script'), Helper::tokenize('app-script'), Helper::tokenize('fontselect'), 'common', 'utils');
             $wp_styles->queue = $styles;
         }
-
-
     }
 
     public static function loadTranslations(){
@@ -843,20 +779,16 @@ class Application
     }
     public static function loadCheckPage()
     {
-
         add_action( 'wp_footer', array(__CLASS__,'loadForm') );
-
     }
 
     public static function loadForm()
     {
-
         $pageId = get_the_ID();
         $forms = self::getFormByPage( $pageId );
         $formLayout = new View();
         $formLayout->setForms( $forms );
         $formLayout->render( 'formLayout', 'public' );
-
     }
 
     private static function getFormByPage($pageId)
@@ -940,7 +872,6 @@ class Application
 
     public static function abTesting()
     {
-        // Application::authenticate();
         $appSettings  = Settings::get();
         $clientId = Settings::get( 'default_client' );
 
@@ -956,7 +887,6 @@ class Application
 
     public static function abTestingEditing()
     {
-        // Application::authenticate();
         $appSettings  = Settings::get();
         $clientId = Settings::get( 'default_client' );
 
@@ -1468,4 +1398,31 @@ class Application
         return stripslashes(htmlspecialchars($string));
     }
 
+    public static function refreshTokenIfNeeded() {
+		$auth = array(
+			'access_token' => Settings::get('access_token'),
+			'refresh_token' => Settings::get('refresh_token')
+		);
+
+		if (!empty($auth['access_token']) && Settings::get('expiry') < time()) {
+            $newCredentials = Application::$CampaignMonitor->refresh_token($auth);
+			
+			if (isset($newCredentials->error)) {
+				// TODO: add some kind of error-handling if API returns error
+				// For now just clear out the tokens
+				Settings::add('access_token', '');
+				Settings::add('refresh_token', '');
+				Settings::add('expiry', '');
+				return false;
+			}
+
+			Settings::add('access_token',$newCredentials->access_token);
+			Settings::add('refresh_token',$newCredentials->refresh_token);
+			Settings::add('expiry', time() + $newCredentials->expires_in);
+
+			return true;
+		}
+
+		return false;
+	}
 }

--- a/forms/core/Application.php
+++ b/forms/core/Application.php
@@ -160,13 +160,9 @@ class Application
                         \wp_redirect( $settingsPage );
                         exit();
                     } else {
-                        Settings::add('access_token', $credentials->access_token);
-                        Settings::add('refresh_token', $credentials->refresh_token);
-                        Settings::add('expiry', time() + $credentials->expires_in);
-                        $appSettings = Settings::get();
+                        Application::updateTokens($credentials->access_token, $credentials->refresh_token, time() + $credentials->expires_in);
                         // we are connected
                         Options::update('connected', TRUE );
-                        CampaignMonitor::update_tokens($credentials->access_token, $credentials->refresh_token);
                         unset($_GET['code']);
                     }
                 }

--- a/forms/core/Application.php
+++ b/forms/core/Application.php
@@ -113,8 +113,6 @@ class Application
             }
         }
 
-        $authorizationToken = Settings::get('access_token');
-
         if (!empty($error)) {
             $description = Request::get('error_description');
 
@@ -1408,9 +1406,7 @@ class Application
             $newCredentials = Application::$CampaignMonitor->refresh_token($auth);
 			
 			if (isset($newCredentials->error)) {
-				// TODO: add some kind of error-handling if API returns error
-				// For now just clear out the tokens
-				Application::updateTokens('', '', 0);
+				error_log('Failed to refresh token');
 				return false;
 			}
 

--- a/forms/core/Application.php
+++ b/forms/core/Application.php
@@ -605,7 +605,7 @@ class Application
 			        }
                 }
 	        }
-        } else if (Application::isConnected() && empty( $appSettings['client_secret'] )) {
+        } else if (Application::isConnected() && (empty( $appSettings['client_secret'] ) || empty( $appSettings['client_id']))) {
             Application::generateConnectionErrorMessage();
         }
 

--- a/forms/core/CampaignMonitor.php
+++ b/forms/core/CampaignMonitor.php
@@ -37,7 +37,8 @@ class CampaignMonitor
      */
     public function refresh_token($auth = array())
     {
-	   return $this->api->refreshToken();
+        $refreshToken = empty($auth) ? '' : $auth->refresh_token;
+        return json_decode($this->api->refreshToken($refreshToken));
     }
     /**
      * @param array $auth override the class authentication credentials
@@ -45,15 +46,16 @@ class CampaignMonitor
      */
     public function get_clients($credentials = array())
     {
+	    if (empty($credentials)) {
+            return (object) ['error' => true];              
+        }
 
-	    if ( ! empty( $credentials ) ) {
-		    $auth = new Authorization();
-		    $auth->setAccessToken($credentials['access_token']);
-		    $auth->setRefreshToken($credentials['refresh_token']);
-		    $auth->setType(Authorization::OAUTH);
+        $auth = new Authorization();
+        $auth->setAccessToken($credentials['access_token']);
+        $auth->setRefreshToken($credentials['refresh_token']);
+        $auth->setType(Authorization::OAUTH);
 
-		    $this->api->setAuthorization( $auth );
-	    }
+        $this->api->setAuthorization( $auth );
 
 	    $clients = $this->api->getClients();
 

--- a/forms/core/CampaignMonitor.php
+++ b/forms/core/CampaignMonitor.php
@@ -50,12 +50,7 @@ class CampaignMonitor
             return (object) ['error' => true];              
         }
 
-        $auth = new Authorization();
-        $auth->setAccessToken($credentials['access_token']);
-        $auth->setRefreshToken($credentials['refresh_token']);
-        $auth->setType(Authorization::OAUTH);
-
-        $this->api->setAuthorization( $auth );
+        $this->update_tokens($credentials['access_token'], $credentials['refresh_token']);
 
 	    $clients = $this->api->getClients();
 

--- a/forms/core/CampaignMonitor.php
+++ b/forms/core/CampaignMonitor.php
@@ -35,16 +35,15 @@ class CampaignMonitor
      * @param array $auth override the class authentication credentials
      * @return mixed|null list of clients
      */
-    public function refresh_token($auth = array())
+    public function refresh_token($auth)
     {
-        $refreshToken = empty($auth) ? '' : $auth['refresh_token'];
-        return json_decode($this->api->refreshToken($refreshToken));
+        return json_decode($this->api->refreshToken($auth['refresh_token']));
     }
     /**
      * @param array $auth override the class authentication credentials
      * @return mixed|null list of clients
      */
-    public function get_clients($credentials = array())
+    public function get_clients($credentials)
     {
 	    if (empty($credentials)) {
             return (object) ['error' => true];              

--- a/forms/core/CampaignMonitor.php
+++ b/forms/core/CampaignMonitor.php
@@ -37,7 +37,7 @@ class CampaignMonitor
      */
     public function refresh_token($auth = array())
     {
-        $refreshToken = empty($auth) ? '' : $auth->refresh_token;
+        $refreshToken = empty($auth) ? '' : $auth['refresh_token'];
         return json_decode($this->api->refreshToken($refreshToken));
     }
     /**
@@ -62,6 +62,16 @@ class CampaignMonitor
 	    return $clients !== null ? json_decode($clients) : $clients;
 
     }
+
+    public function update_tokens($accessToken, $refreshToken) {
+        $auth = new Authorization();
+        $auth->setAccessToken($accessToken);
+        $auth->setRefreshToken($refreshToken);
+        $auth->setType(Authorization::OAUTH);
+
+        $this->api->setAuthorization($auth);
+    }
+
     /**
      * @param array $auth override the class authentication credentials
      * @return mixed|null list of clients


### PR DESCRIPTION
Adding refresh method that actually gets called (on run and on API calls). Amongst some other code clean up.

Should I also refresh the token on every page?