### PR TITLE
DNA-470.Fix sub confirmation Window Style issue

### DIFF
--- a/forms/views/public/css/app.css
+++ b/forms/views/public/css/app.css
@@ -73,7 +73,7 @@
 
 .cmApp_signupContainer .cmApp_processing #cmApp_thankYouCheck img
 {
-    margin: 1px auto 1px;
+    display: inline;
 }
 
 .hidden {

--- a/forms/views/public/css/app.css
+++ b/forms/views/public/css/app.css
@@ -71,6 +71,11 @@
     visibility: visible;
 }
 
+.cmApp_signupContainer .cmApp_processing #cmApp_thankYouCheck img
+{
+    margin: 1px auto 1px;
+}
+
 .hidden {
     display: none;
     visibility: hidden;


### PR DESCRIPTION
Add css to position the sub confirmation logo in the middle of the window for wordpress 5.4