### PR TITLE
DNA-471 Fixing bar misalignment on 2020 theme

### DIFF
--- a/forms/views/public/css/app.css
+++ b/forms/views/public/css/app.css
@@ -6,18 +6,17 @@
     width:288px;
 }*/
 
-
 .campaign-monitor-custom-field {
     margin: 1em;
 }
-.campaign-monitor-custom-field label{
+.campaign-monitor-custom-field label {
     display: block;
 }
 
 .campaign-monitor-custom-field select {
-    padding:  1em;
-    background: none    ;
-    background-color: #FFF;
+    padding: 1em;
+    background: none;
+    background-color: #fff;
     margin: 5px 0 0;
     width: 100%;
     font-size: 14px;
@@ -25,17 +24,15 @@
 }
 
 .cm-form-bar {
-
 }
-.cmApp_bar .cmApp_signupFormWrapper .g-recaptcha{
-
+.cmApp_bar .cmApp_signupFormWrapper .g-recaptcha {
     clear: none;
     margin-top: -0.3em;
 }
 
-.cmApp_signupContainer.cmApp_bar .cmApp_signupFormWrapper input[type='text'],
-.cmApp_signupContainer.cmApp_bar .cmApp_signupFormWrapper input[type='date'],
-.cmApp_signupContainer.cmApp_bar .cmApp_signupFormWrapper input[type='number'],
+.cmApp_signupContainer.cmApp_bar .cmApp_signupFormWrapper input[type="text"],
+.cmApp_signupContainer.cmApp_bar .cmApp_signupFormWrapper input[type="date"],
+.cmApp_signupContainer.cmApp_bar .cmApp_signupFormWrapper input[type="number"],
 .cmApp_signupContainer.cmApp_bar .cmApp_signupFormWrapper select {
     width: auto;
     margin-left: 1em;
@@ -43,28 +40,30 @@
 .cmApp_signupContainer.cmApp_bar .cmApp_signupFormWrapper label {
     margin-right: 0.5em;
     width: auto;
-
 }
-.cmApp_signupContainer.cmApp_bar .cmApp_signupFormWrapper .cm-multi  label:first-child {
+.cmApp_signupContainer.cmApp_bar
+    .cmApp_signupFormWrapper
+    .cm-multi
+    label:first-child {
     float: left;
-
 }
 .cmApp_signupContainer.cmApp_bar .cmApp_signupFormWrapper ul,
 .cmApp_signupContainer.cmApp_bar .cmApp_signupFormWrapper ul li {
     display: inline-block;
 }
 
-
-.cmApp_signupContainer.cmApp_slideoutTab .cmApp_formHeader, .cmApp_signupContainer.cmApp_slideoutTab .cmApp_formSubHeader,
-.cmApp_signupContainer.cmApp_lightbox .cmApp_formHeader,    .cmApp_signupContainer.cmApp_lightbox .cmApp_formSubHeader,
-.cmApp_signupContainer.cmApp_embedded .cmApp_formHeader,    .cmApp_signupContainer.cmApp_embedded .cmApp_formSubHeader
-{
-    text-align:center;
+.cmApp_signupContainer.cmApp_slideoutTab .cmApp_formHeader,
+.cmApp_signupContainer.cmApp_slideoutTab .cmApp_formSubHeader,
+.cmApp_signupContainer.cmApp_lightbox .cmApp_formHeader,
+.cmApp_signupContainer.cmApp_lightbox .cmApp_formSubHeader,
+.cmApp_signupContainer.cmApp_embedded .cmApp_formHeader,
+.cmApp_signupContainer.cmApp_embedded .cmApp_formSubHeader {
+    text-align: center;
 }
 
 #cmApp_statusContainer .cmApp_processingMsg {
     /*white-space: normal;*/
-    white-space:nowrap;
+    white-space: nowrap;
 }
 
 .cmApp_signupContainer .cmApp_processing #cmApp_thankYouCheck {
@@ -76,25 +75,33 @@
     visibility: hidden;
 }
 
-.show{
+.show {
     display: block;
     visibility: visible;
-
 }
 
-.cmApp_signupContainer.cmApp_bar #cmApp_errorAll div { display:block;clear:both; }
-.cmApp_signupContainer.cmApp_bar #cmApp_errorAll div:first-child { margin-top:-4px; }
-
-.cmApp_bar #cmApp_thankYouCheck img
-{
-    max-height:40px;
-    width:auto;
+.cmApp_signupContainer.cmApp_bar #cmApp_errorAll div {
+    display: block;
+    clear: both;
+}
+.cmApp_signupContainer.cmApp_bar #cmApp_errorAll div:first-child {
+    margin-top: -4px;
 }
 
-.cmApp_bar #cmApp_statusContainer p
-{
-    margin-bottom:0;
+.cmApp_bar #cmApp_thankYouCheck img {
+    max-height: 40px;
+    width: auto;
 }
+
+.cmApp_bar #cmApp_statusContainer p {
+    margin-bottom: 0;
+}
+
+.cmApp_bar .cmApp_formInput label,
+.cmApp_bar .cmApp_formInput input {
+    display: inline;
+}
+
 .cmApp_signupContainer.cmApp_bar div.cmApp_processingMsg {
     padding: 0.25em;
 }


### PR DESCRIPTION
And some linting apparently.

From:
<img width="717" alt="Screen Shot 2020-03-23 at 3 45 53 pm" src="https://user-images.githubusercontent.com/31084566/77282219-6b4e6380-6d1d-11ea-8e22-7fcba47ee9c4.png">
To:
<img width="848" alt="Screen Shot 2020-03-23 at 3 45 29 pm" src="https://user-images.githubusercontent.com/31084566/77282215-68ec0980-6d1d-11ea-85df-bf241e331782.png">

A rogue `display: block` on label and input in the 2020 theme has caused the styling error

