### PR TITLE
DNA-515 -- Update the issue with form targetting other pages

### DIFF
--- a/campaign-monitor.php
+++ b/campaign-monitor.php
@@ -5,7 +5,7 @@ defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
  * Plugin Name: Campaign Monitor for WordPress
  * Plugin URI: http://campaignmonitor.com
  * Description: Manage Campaign Monitor Lists, Custom Fields and add forms and how you show them to your users..
- * Version: 2.8.2
+ * Version: 2.8.3
  * Author: Campaign Monitor
  * Author URI: http://campaignmonitor.com
  * License: License: GPLv2 or later

--- a/forms/views/public/css/app.css
+++ b/forms/views/public/css/app.css
@@ -98,7 +98,7 @@
 }
 
 .cmApp_bar #cmApp_statusContainer p {
-    margin-bottom: 0;
+    margin: 0;
 }
 
 .cmApp_bar .cmApp_formInput label,

--- a/forms/views/public/css/app.css
+++ b/forms/views/public/css/app.css
@@ -70,8 +70,7 @@
     visibility: visible;
 }
 
-.cmApp_signupContainer .cmApp_processing #cmApp_thankYouCheck img
-{
+.cmApp_signupContainer .cmApp_processing #cmApp_thankYouCheck img {
     display: inline;
 }
 

--- a/forms/views/public/formLayout.php
+++ b/forms/views/public/formLayout.php
@@ -157,7 +157,7 @@ if (is_null($form))
 
 
                         if (!empty( $current_url )) {
-                            if (strpos($pageUrl, $current_url) !== False){
+                            if ($pageUrl === $current_url){
                                 $addThisPage = true;
 
                             }

--- a/readme.txt
+++ b/readme.txt
@@ -63,6 +63,9 @@ When we launched 2.0, we improved how our plugin saves forms in the WordPress da
 
 == Changelog ==
 
+= 2.8.3 =
+* Fix where form is targetting more than specified page(s).
+
 = 2.8.2 =
 * Further improvements to address connectivity issues.
 * Minor UI changes for WordPress 5.3.


### PR DESCRIPTION
The issue was that when determining if the form should be displayed or not, it checked the 'pageurl' of where the form should be displayed against the 'currenturl'. The check though needs that the url is within the other url, meaning that if the page was in /subscribe-to-our-list/ and the current url is /subscribe/ it would be picked up as well. Change is making the chck as 'equality' check. Testing it with url like /subscribe/ as well as standard url of /?page=325