### PR TITLE
EL-892 -- Update version for Wordpress

### DIFF
--- a/campaign-monitor.php
+++ b/campaign-monitor.php
@@ -5,7 +5,7 @@ defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
  * Plugin Name: Campaign Monitor for WordPress
  * Plugin URI: http://campaignmonitor.com
  * Description: Manage Campaign Monitor Lists, Custom Fields and add forms and how you show them to your users..
- * Version: 2.8.9
+ * Version: 2.8.10
  * Author: Campaign Monitor
  * Author URI: http://campaignmonitor.com
  * License: License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Donate link: N/A
 Tags: Campaign Monitor, Email Marketing, Sign-Up Forms, Sign Up Forms
 Requires at least: 3.9
 Requires PHP: 5.3
-Tested up to: 6.0
-Stable tag: 2.8.9
+Tested up to: 6.1
+Stable tag: 2.8.10
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -62,6 +62,7 @@ When we launched 2.0, we improved how our plugin saves forms in the WordPress da
 7. Easy to add a new form. Just select the form type, choose the Campaign Monitor List where  data will be collected, and you are done.
 
 == Changelog ==
+= 2.8.10 =
 
 = 2.8.9 =
 


### PR DESCRIPTION
Updating the Wordpress version to version 6.1 
Tested in https://campmon.com/jira/browse/EL-891 (https://docs.google.com/spreadsheets/d/1nOIaiqM63aaCcOU-VfBHjxCiGviv6P49JiXcbegoUJg/edit#gid=1573956975)
Following PR https://github.com/campaignmonitor/forms-for-campaign-monitor/pull/42