### PR TITLE
EL-892 -- Update to commented out parent:: method that wasn't extended any class

### DIFF
--- a/campaign-monitor.php
+++ b/campaign-monitor.php
@@ -5,7 +5,7 @@ defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
  * Plugin Name: Campaign Monitor for WordPress
  * Plugin URI: http://campaignmonitor.com
  * Description: Manage Campaign Monitor Lists, Custom Fields and add forms and how you show them to your users..
- * Version: 2.8.9
+ * Version: 2.8.10
  * Author: Campaign Monitor
  * Author URI: http://campaignmonitor.com
  * License: License: GPLv2 or later

--- a/forms/core/Form/Element/AbstractElement.php
+++ b/forms/core/Form/Element/AbstractElement.php
@@ -64,7 +64,9 @@ abstract class AbstractElement
             $this->getForm()->addElementToCollection($element);
         }
 
-        parent::addElement($element, $after);
+        // Commenting the following line as "parent keyword without parent class" is deprecated in PHP 7.4
+        // This method doesn't seem to be used anyway and currently throwing an error due to wordpress custom hook script
+        // parent::addElement($element, $after);
         return $this;
     }
 

--- a/forms/core/Form/Element/AbstractElement.php
+++ b/forms/core/Form/Element/AbstractElement.php
@@ -171,7 +171,10 @@ abstract class AbstractElement
     public function removeField($elementId)
     {
         $this->getForm()->removeField($elementId);
-        return parent::removeField($elementId);
+
+        // Commenting the following line as "parent keyword without parent class" is deprecated in PHP 7.4
+        // This method doesn't seem to be used anyway and currently throwing an error due to wordpress custom hook script
+        // return parent::removeField($elementId);
     }
 
     /**
@@ -444,7 +447,10 @@ abstract class AbstractElement
         } else {
             unset($this->_data['checked']);
         }
-        return parent::serialize($attributes, $valueSeparator, $fieldSeparator, $quote);
+
+        // Commenting the following line as "parent keyword without parent class" is deprecated in PHP 7.4
+        // This method doesn't seem to be used anyway and currently throwing an error due to wordpress custom hook script
+        // return parent::serialize($attributes, $valueSeparator, $fieldSeparator, $quote);
     }
 
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Donate link: N/A
 Tags: Campaign Monitor, Email Marketing, Sign-Up Forms, Sign Up Forms
 Requires at least: 3.9
 Requires PHP: 5.3
-Tested up to: 6.0
-Stable tag: 2.8.9
+Tested up to: 6.1
+Stable tag: 2.8.10
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -62,6 +62,7 @@ When we launched 2.0, we improved how our plugin saves forms in the WordPress da
 7. Easy to add a new form. Just select the form type, choose the Campaign Monitor List where  data will be collected, and you are done.
 
 == Changelog ==
+= 2.8.10 =
 
 = 2.8.9 =
 


### PR DESCRIPTION
This is deprecated at PHP 7.4
It would otherwise failed before at run-time, in which after 7.4 would fail at compile time. 
Had a quick check that the methods that were commented out isn't used anywhere else. The serialize method is used by getElementHtml which isn't used anywhere else. Wasn't confident in removing the whole file as I'm not intending to test everything again (will smoke test this once it's pushed out)