### PR TITLE
MER-795 - Remove uses of FILTER_SANITIZE_STRING

### DIFF
--- a/forms/core/Ajax.php
+++ b/forms/core/Ajax.php
@@ -279,7 +279,7 @@ abstract class Ajax
 					$redirectUrl = $_SERVER['HTTP_REFERER'];
 				}
 
-                echo sprintf("<div style='text-align: center; padding: 2em;'>%s<br><br>Click here to <a href='%s'>go back</a></div>", filter_var($response->success_message, FILTER_SANITIZE_STRING), filter_var($redirectUrl, FILTER_SANITIZE_STRING));
+                echo sprintf("<div style='text-align: center; padding: 2em;'>%s<br><br>Click here to <a href='%s'>go back</a></div>", htmlspecialchars($response->success_message), htmlspecialchars($redirectUrl));
 				exit();
 			}
 

--- a/forms/core/Ajax.php
+++ b/forms/core/Ajax.php
@@ -279,7 +279,7 @@ abstract class Ajax
 					$redirectUrl = $_SERVER['HTTP_REFERER'];
 				}
 
-                echo sprintf("<div style='text-align: center; padding: 2em;'>%s<br><br>Click here to <a href='%s'>go back</a></div>", htmlspecialchars($response->success_message), htmlspecialchars($redirectUrl));
+                echo sprintf("<div style='text-align: center; padding: 2em;'>%s<br><br>Click here to <a href='%s'>go back</a></div>", Security::sanitize($response->success_message), Security::sanitize($redirectUrl));
 				exit();
 			}
 

--- a/forms/core/Application.php
+++ b/forms/core/Application.php
@@ -119,7 +119,7 @@ class Application
             $html = '<div class="wrap">';
             $html .= '<h1>Campaign Monitor</h1>';
             $html .= '<div  id="error" class="error">';
-            $html .= $error;
+            $html .= htmlspecialchars($error);
             $html .= '</div><!-- end error-->';
             $html .= '</div><!-- end wrap-->';
 

--- a/forms/core/Application.php
+++ b/forms/core/Application.php
@@ -615,7 +615,7 @@ class Application
         <div class="update-nag error is-dismissible notice">
             <p>
                 There seems to be a problem with your credentials please disconnect and reconnect your account on the
-                <a href="<?php echo  get_admin_url() . '/admin.php?page=campaign_monitor_settings_page&notice[description]='.filter_var($message,FILTER_SANITIZE_STRING).'&notice[title]=Notice!' ?>"> Campaign Monitor Settings </a> page
+                <a href="<?php echo  get_admin_url() . '/admin.php?page=campaign_monitor_settings_page&notice[description]='.htmlspecialchars($message).'&notice[title]=Notice!' ?>"> Campaign Monitor Settings </a> page
             </p>
         </div>
         <?php

--- a/forms/core/Application.php
+++ b/forms/core/Application.php
@@ -119,7 +119,7 @@ class Application
             $html = '<div class="wrap">';
             $html .= '<h1>Campaign Monitor</h1>';
             $html .= '<div  id="error" class="error">';
-            $html .= htmlspecialchars($error);
+            $html .= Security::sanitize($error);
             $html .= '</div><!-- end error-->';
             $html .= '</div><!-- end wrap-->';
 
@@ -615,7 +615,7 @@ class Application
         <div class="update-nag error is-dismissible notice">
             <p>
                 There seems to be a problem with your credentials please disconnect and reconnect your account on the
-                <a href="<?php echo  get_admin_url() . '/admin.php?page=campaign_monitor_settings_page&notice[description]='.htmlspecialchars($message).'&notice[title]=Notice!' ?>"> Campaign Monitor Settings </a> page
+                <a href="<?php echo  get_admin_url() . '/admin.php?page=campaign_monitor_settings_page&notice[description]='.Security::sanitize($message).'&notice[title]=Notice!' ?>"> Campaign Monitor Settings </a> page
             </p>
         </div>
         <?php

--- a/forms/core/Form.php
+++ b/forms/core/Form.php
@@ -231,7 +231,7 @@ class Form
             $campaignMonitorClientAr = array();
             foreach ($clients as $client)
             {
-                $campaignMonitorClientAr[$client->ClientID] = htmlspecialchars($client->Name);
+                $campaignMonitorClientAr[$client->ClientID] = Security::sanitize($client->Name);
             }
         }
         $this->campaignMonitorClientAr = $campaignMonitorClientAr;

--- a/forms/core/Form.php
+++ b/forms/core/Form.php
@@ -231,7 +231,7 @@ class Form
             $campaignMonitorClientAr = array();
             foreach ($clients as $client)
             {
-                $campaignMonitorClientAr[$client->ClientID] = filter_var($client->Name, FILTER_SANITIZE_STRING);
+                $campaignMonitorClientAr[$client->ClientID] = htmlspecialchars($client->Name);
             }
         }
         $this->campaignMonitorClientAr = $campaignMonitorClientAr;

--- a/forms/core/Helper.php
+++ b/forms/core/Helper.php
@@ -118,13 +118,13 @@ abstract class Helper {
         <div id="TB_window" class="thickbox-loading" style="visibility: visible" >
             <div id="TB_title">
             <div id="TB_ajaxWindowTitle">
-                '.htmlspecialchars($title).'
+                '.Security::sanitize($title).'
              </div>
              <div id="TB_closeAjaxWindow"><button type="button" id="TB_closeWindowButton">
                         <span class="screen-reader-text">Close</span><span class="tb-close-icon">
                         </span></button></div></div>
             <div id="TB_ajaxContent">
-            '.htmlspecialchars($body).'
+            '.Security::sanitize($body).'
             </div>
         </div>
         ';

--- a/forms/core/Helper.php
+++ b/forms/core/Helper.php
@@ -118,13 +118,13 @@ abstract class Helper {
         <div id="TB_window" class="thickbox-loading" style="visibility: visible" >
             <div id="TB_title">
             <div id="TB_ajaxWindowTitle">
-                '.filter_var($title, FILTER_SANITIZE_STRING).'
+                '.htmlspecialchars($title).'
              </div>
              <div id="TB_closeAjaxWindow"><button type="button" id="TB_closeWindowButton">
                         <span class="screen-reader-text">Close</span><span class="tb-close-icon">
                         </span></button></div></div>
             <div id="TB_ajaxContent">
-            '.filter_var($body, FILTER_SANITIZE_STRING).'
+            '.htmlspecialchars($body).'
             </div>
         </div>
         ';

--- a/forms/core/Security.php
+++ b/forms/core/Security.php
@@ -28,7 +28,7 @@ class Security
     }
     
     public static function sanitize($input){
-       return htmlspecialchars($input, ENT_QUOTES, 'UTF-8');
+       return htmlspecialchars($input, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, 'UTF-8');
     }
 
     public static function canUseCaptcha(){

--- a/forms/views/admin/ab-testing-edit.php
+++ b/forms/views/admin/ab-testing-edit.php
@@ -4,6 +4,7 @@ use forms\core\Request;
 use forms\core\FormType;
 use forms\core\ABTest;
 use forms\core\Helper;
+use forms\core\Security;
 
 /**
  * Delete item please see Application::abTesting();
@@ -86,7 +87,7 @@ $pages = Helper::getPages();
                     <input type="hidden" name="action" value="handle_cm_form_request">
                     <input type="hidden" name="data[type]" value="save_ab_test">
                     <input type="hidden" name="data[app_nonce]" value="<?php echo wp_create_nonce( 'app_nonce' ); ?>">
-                    <input type="hidden" name="test_id" value="<?php echo htmlspecialchars(($currentTest==null) ? "" : $currentTest->getId()); ?>" />
+                    <input type="hidden" name="test_id" value="<?php echo ($currentTest==null) ? "" : Security::sanitize($currentTest->getId()); ?>" />
 
                     <?Php if ($currentTest !== null ) : ?>
                         <lable>Test Title: </lable>
@@ -134,13 +135,13 @@ $pages = Helper::getPages();
                                             <span class="screen-reader-text">Show more details</span></button>
                                     </td>
                                     <td class="type column-type" data-colname="Type">
-                                        <?php echo htmlspecialchars($test->getImpressions()); ?>
+                                        <?php echo Security::sanitize(filter_var($test->getImpressions(), FILTER_SANITIZE_NUMBER_INT)); ?>
                                     </td>
                                     <td class="pages column-pages" data-colname="Type">
-                                        <?php echo htmlspecialchars($test->getSubmissions()); ?>
+                                        <?php echo Security::sanitize(filter_var($test->getSubmissions(), FILTER_SANITIZE_NUMBER_INT)); ?>
                                     </td>
                                     <td class="pages column-pages" data-colname="Type">
-                                        <?php echo htmlspecialchars(round($test->getSubmissionRate(), 2) * 100); ?>%
+                                        <?php echo Security::sanitize(round(filter_var($test->getSubmissionRate(), FILTER_SANITIZE_NUMBER_INT), 2) * 100); ?>%
                                     </td>
                                 </tr>
                             <?php  endforeach; ?>

--- a/forms/views/admin/ab-testing-edit.php
+++ b/forms/views/admin/ab-testing-edit.php
@@ -86,7 +86,7 @@ $pages = Helper::getPages();
                     <input type="hidden" name="action" value="handle_cm_form_request">
                     <input type="hidden" name="data[type]" value="save_ab_test">
                     <input type="hidden" name="data[app_nonce]" value="<?php echo wp_create_nonce( 'app_nonce' ); ?>">
-                    <input type="hidden" name="test_id" value="<?php echo ($currentTest==null) ? "" : filter_var($currentTest->getId(), FILTER_SANITIZE_STRING); ?>" />
+                    <input type="hidden" name="test_id" value="<?php echo htmlspecialchars(($currentTest==null) ? "" : $currentTest->getId()); ?>" />
 
                     <?Php if ($currentTest !== null ) : ?>
                         <lable>Test Title: </lable>
@@ -134,13 +134,13 @@ $pages = Helper::getPages();
                                             <span class="screen-reader-text">Show more details</span></button>
                                     </td>
                                     <td class="type column-type" data-colname="Type">
-                                        <?php echo filter_var($test->getImpressions(), FILTER_SANITIZE_STRING); ?>
+                                        <?php echo htmlspecialchars($test->getImpressions()); ?>
                                     </td>
                                     <td class="pages column-pages" data-colname="Type">
-                                        <?php echo filter_var($test->getSubmissions(), FILTER_SANITIZE_STRING);; ?>
+                                        <?php echo htmlspecialchars($test->getSubmissions()); ?>
                                     </td>
                                     <td class="pages column-pages" data-colname="Type">
-                                        <?php echo filter_var(round($test->getSubmissionRate(), 2) * 100, FILTER_SANITIZE_STRING); ?>%
+                                        <?php echo htmlspecialchars(round($test->getSubmissionRate(), 2) * 100); ?>%
                                     </td>
                                 </tr>
                             <?php  endforeach; ?>

--- a/forms/views/admin/ab-testing.php
+++ b/forms/views/admin/ab-testing.php
@@ -76,10 +76,10 @@ if (!empty( $notices )) {
 
     $html = '<div id="message" class="notice-success notice is-dismissible">';
     $html .= '<h2>';
-    $html .= $notices['title'];
+    $html .= htmlspecialchars($notices['title']);
     $html .= '</h2>';
     $html .= '<p>';
-    $html .=  $notices['description'];
+    $html .=  htmlspecialchars($notices['description']);
     $html .= '</p>';
     $html .= '<button type="button" class="notice-dismiss"><span class="screen-reader-text">Dismiss this notice.</span></button>';
     $html .= '</div><!-- .updated -->';

--- a/forms/views/admin/ab-testing.php
+++ b/forms/views/admin/ab-testing.php
@@ -4,6 +4,7 @@ use forms\core\Request;
 use forms\core\FormType;
 use forms\core\Form;
 use forms\core\Helper;
+use forms\core\Security;
 
 
 
@@ -76,10 +77,10 @@ if (!empty( $notices )) {
 
     $html = '<div id="message" class="notice-success notice is-dismissible">';
     $html .= '<h2>';
-    $html .= htmlspecialchars($notices['title']);
+    $html .= Security::sanitize($notices['title']);
     $html .= '</h2>';
     $html .= '<p>';
-    $html .=  htmlspecialchars($notices['description']);
+    $html .=  Security::sanitize($notices['description']);
     $html .= '</p>';
     $html .= '<button type="button" class="notice-dismiss"><span class="screen-reader-text">Dismiss this notice.</span></button>';
     $html .= '</div><!-- .updated -->';

--- a/forms/views/admin/builder.php
+++ b/forms/views/admin/builder.php
@@ -100,14 +100,14 @@ $openTextFieldLabel = $form->getOpenTextFieldLabel();
 $hasGenderField = $form->getHasGenderField();
 $hasCampMonLogo = $form->getHasCampMonLogo();
 $submitButtonBgHex = $form->getSubmitButtonBgHex();
-$submitButtonBgHex = str_replace( '#', '', filter_var($submitButtonBgHex, FILTER_SANITIZE_STRING));
+$submitButtonBgHex = str_replace( '#', '', htmlspecialchars($submitButtonBgHex));
 
 $submitButtonTextHex = $form->getSubmitButtonTextHex();
-$submitButtonTextHex = str_replace( '#', '', filter_var($submitButtonTextHex, FILTER_SANITIZE_STRING));
+$submitButtonTextHex = str_replace( '#', '', htmlspecialchars($submitButtonTextHex));
 $backgroundHex = $form->getBackgroundHex();
-$backgroundHex = str_replace( '#', '', filter_var($backgroundHex, FILTER_SANITIZE_STRING));
+$backgroundHex = str_replace( '#', '', htmlspecialchars($backgroundHex));
 $textHex = $form->getTextHex();
-$textHex = str_replace( '#', '', filter_var($textHex, FILTER_SANITIZE_STRING));
+$textHex = str_replace( '#', '', htmlspecialchars($textHex));
 $submitButtonText = $form->getSubmitButtonText();
 $formEmbedCode = $form->getFormEmbedCode();
 $isActive = $form->getIsActive();
@@ -212,14 +212,14 @@ if ($isUpdated)
                     <form id="signupFormForm" action="<?php echo get_admin_url(); ?>admin-post.php" method="post">
                         <input type="hidden" name="action" value="handle_cm_form_request">
                         <input type="hidden" name="data[type]" value="save">
-                        <input type="hidden" name="formId" value="<?php echo filter_var($id, FILTER_SANITIZE_STRING); ?>">
+                        <input type="hidden" name="formId" value="<?php echo htmlspecialchars($id); ?>">
                         <input type="hidden" name="createDate" value="<?php echo htmlDecodeEncode($createDate); ?>">
                         <input type="hidden" name="data[app_nonce]" value="<?php echo wp_create_nonce( 'app_nonce' ); ?>">
 
                         <div><label>Form name</label><?php echo Field::text('formName',htmlDecodeEncode($name), 'id="formName" maxlength="255"'); ?></div>
 
                         <div><label>Client</label><?php
-                            echo Field::select('campaignMonitorClientId',$campaignMonitorClientAr, filter_var($campaignMonitorClientId, FILTER_SANITIZE_STRING),'id="campaignMonitorClientId" class="postAjax"');
+                            echo Field::select('campaignMonitorClientId',$campaignMonitorClientAr, htmlspecialchars($campaignMonitorClientId),'id="campaignMonitorClientId" class="postAjax"');
                             ?></div>
 
                         <div id="campaignMonitorListIdCon" style="display:none;"><label>List &nbsp; <span style="float:right;">
@@ -230,7 +230,7 @@ if ($isUpdated)
 
 
                             echo Field::select('campaignMonitorListId',array(), "", 'id="campaignMonitorListId"');
-                            echo Field::hidden('campaignMonitorListIdCurrent', filter_var($campaignMonitorListId, FILTER_SANITIZE_STRING),'id="campaignMonitorListIdCurrent"');
+                            echo Field::hidden('campaignMonitorListIdCurrent', htmlspecialchars($campaignMonitorListId),'id="campaignMonitorListIdCurrent"');
                             ?></div>
                         <div id="campaignMonitorListUpdateMessage" style="display:none;"><em>Updating Lists...</em></div>
 
@@ -263,7 +263,7 @@ if ($isUpdated)
                         </div>
                         <div></div>
 
-                        <div><label>Form type</label><div><?php echo Field::select("formType",$typeAr, filter_var($type, FILTER_SANITIZE_STRING), 'id="formType"'); ?></div></div>
+                        <div><label>Form type</label><div><?php echo Field::select("formType",$typeAr, htmlspecialchars($type), 'id="formType"'); ?></div></div>
 
                         <div><label>Page(s) this form appears on</label><div class="newPageInputCon">
                                 <?php
@@ -398,10 +398,10 @@ if ($isUpdated)
                         <div id="formAppearsLightboxCon"><label>Form appears</label>
                             <div><input type="radio" name="formAppearsLightbox" class="styledRadio" id="formAppearsLightboxSeconds" value="seconds"<?php if ($formAppearsLightbox=="seconds") {echo " checked=\"checked\"";} ?> />
                                 <label for="formAppearsLightboxSeconds" id="formAppearsLightboxSecondsLabel"><span><span></span></span>
-                                    After <?php echo Field::text("lightboxSeconds", filter_var($lightboxSeconds, FILTER_SANITIZE_STRING), 'id="lightboxSeconds" maxlength="3"'); ?> seconds</label></div>
+                                    After <?php echo Field::text("lightboxSeconds", htmlspecialchars($lightboxSeconds), 'id="lightboxSeconds" maxlength="3"'); ?> seconds</label></div>
                             <div><input type="radio" name="formAppearsLightbox" class="styledRadio" id="formAppearsLightboxScroll" value="scroll"<?php if ($formAppearsLightbox=="scroll") {echo " checked=\"checked\"";} ?> />
                                 <label for="formAppearsLightboxScroll" id="formAppearsLightboxScrollLabel"><span><span></span></span>
-                                    After scrolling <?php echo Field::text("lightboxScrollPercent", filter_var($lightboxScrollPercent, FILTER_SANITIZE_STRING), 'id="lightboxScrollPercent"'); ?> %</label></div>
+                                    After scrolling <?php echo Field::text("lightboxScrollPercent", htmlspecialchars($lightboxScrollPercent), 'id="lightboxScrollPercent"'); ?> %</label></div>
                         </div>
 
                         <div id="formPlacementCon"><label>Form slides out from</label>

--- a/forms/views/admin/builder.php
+++ b/forms/views/admin/builder.php
@@ -5,6 +5,7 @@ use \forms\core\Log;
 use \forms\core\Settings;
 use \forms\core\FormType;
 use \forms\core\HtmlFields as Field;
+use \forms\core\Security;
 
 
 $this->sanitize();
@@ -100,14 +101,14 @@ $openTextFieldLabel = $form->getOpenTextFieldLabel();
 $hasGenderField = $form->getHasGenderField();
 $hasCampMonLogo = $form->getHasCampMonLogo();
 $submitButtonBgHex = $form->getSubmitButtonBgHex();
-$submitButtonBgHex = str_replace( '#', '', htmlspecialchars($submitButtonBgHex));
+$submitButtonBgHex = str_replace( '#', '', Security::sanitize($submitButtonBgHex));
 
 $submitButtonTextHex = $form->getSubmitButtonTextHex();
-$submitButtonTextHex = str_replace( '#', '', htmlspecialchars($submitButtonTextHex));
+$submitButtonTextHex = str_replace( '#', '', Security::sanitize($submitButtonTextHex));
 $backgroundHex = $form->getBackgroundHex();
-$backgroundHex = str_replace( '#', '', htmlspecialchars($backgroundHex));
+$backgroundHex = str_replace( '#', '', Security::sanitize($backgroundHex));
 $textHex = $form->getTextHex();
-$textHex = str_replace( '#', '', htmlspecialchars($textHex));
+$textHex = str_replace( '#', '', Security::sanitize($textHex));
 $submitButtonText = $form->getSubmitButtonText();
 $formEmbedCode = $form->getFormEmbedCode();
 $isActive = $form->getIsActive();
@@ -212,14 +213,14 @@ if ($isUpdated)
                     <form id="signupFormForm" action="<?php echo get_admin_url(); ?>admin-post.php" method="post">
                         <input type="hidden" name="action" value="handle_cm_form_request">
                         <input type="hidden" name="data[type]" value="save">
-                        <input type="hidden" name="formId" value="<?php echo htmlspecialchars($id); ?>">
+                        <input type="hidden" name="formId" value="<?php echo Security::sanitize($id); ?>">
                         <input type="hidden" name="createDate" value="<?php echo htmlDecodeEncode($createDate); ?>">
                         <input type="hidden" name="data[app_nonce]" value="<?php echo wp_create_nonce( 'app_nonce' ); ?>">
 
                         <div><label>Form name</label><?php echo Field::text('formName',htmlDecodeEncode($name), 'id="formName" maxlength="255"'); ?></div>
 
                         <div><label>Client</label><?php
-                            echo Field::select('campaignMonitorClientId',$campaignMonitorClientAr, htmlspecialchars($campaignMonitorClientId),'id="campaignMonitorClientId" class="postAjax"');
+                            echo Field::select('campaignMonitorClientId',$campaignMonitorClientAr, Security::sanitize($campaignMonitorClientId),'id="campaignMonitorClientId" class="postAjax"');
                             ?></div>
 
                         <div id="campaignMonitorListIdCon" style="display:none;"><label>List &nbsp; <span style="float:right;">
@@ -230,7 +231,7 @@ if ($isUpdated)
 
 
                             echo Field::select('campaignMonitorListId',array(), "", 'id="campaignMonitorListId"');
-                            echo Field::hidden('campaignMonitorListIdCurrent', htmlspecialchars($campaignMonitorListId),'id="campaignMonitorListIdCurrent"');
+                            echo Field::hidden('campaignMonitorListIdCurrent', Security::sanitize($campaignMonitorListId),'id="campaignMonitorListIdCurrent"');
                             ?></div>
                         <div id="campaignMonitorListUpdateMessage" style="display:none;"><em>Updating Lists...</em></div>
 
@@ -263,7 +264,7 @@ if ($isUpdated)
                         </div>
                         <div></div>
 
-                        <div><label>Form type</label><div><?php echo Field::select("formType",$typeAr, htmlspecialchars($type), 'id="formType"'); ?></div></div>
+                        <div><label>Form type</label><div><?php echo Field::select("formType",$typeAr, Security::sanitize($type), 'id="formType"'); ?></div></div>
 
                         <div><label>Page(s) this form appears on</label><div class="newPageInputCon">
                                 <?php
@@ -398,10 +399,10 @@ if ($isUpdated)
                         <div id="formAppearsLightboxCon"><label>Form appears</label>
                             <div><input type="radio" name="formAppearsLightbox" class="styledRadio" id="formAppearsLightboxSeconds" value="seconds"<?php if ($formAppearsLightbox=="seconds") {echo " checked=\"checked\"";} ?> />
                                 <label for="formAppearsLightboxSeconds" id="formAppearsLightboxSecondsLabel"><span><span></span></span>
-                                    After <?php echo Field::text("lightboxSeconds", htmlspecialchars($lightboxSeconds), 'id="lightboxSeconds" maxlength="3"'); ?> seconds</label></div>
+                                    After <?php echo Field::text("lightboxSeconds", Security::sanitize($lightboxSeconds), 'id="lightboxSeconds" maxlength="3"'); ?> seconds</label></div>
                             <div><input type="radio" name="formAppearsLightbox" class="styledRadio" id="formAppearsLightboxScroll" value="scroll"<?php if ($formAppearsLightbox=="scroll") {echo " checked=\"checked\"";} ?> />
                                 <label for="formAppearsLightboxScroll" id="formAppearsLightboxScrollLabel"><span><span></span></span>
-                                    After scrolling <?php echo Field::text("lightboxScrollPercent", htmlspecialchars($lightboxScrollPercent), 'id="lightboxScrollPercent"'); ?> %</label></div>
+                                    After scrolling <?php echo Field::text("lightboxScrollPercent", Security::sanitize($lightboxScrollPercent), 'id="lightboxScrollPercent"'); ?> %</label></div>
                         </div>
 
                         <div id="formPlacementCon"><label>Form slides out from</label>
@@ -414,7 +415,6 @@ if ($isUpdated)
                             <div><input type="radio" name="formPlacement" class="styledRadio" id="formPlacementBR" value="bottomRight"<?php if ($formPlacement=="bottomRight") {echo " checked=\"checked\"";} ?> />
                                 <label for="formPlacementBR"><span><span></span></span> Bottom right</label></div>
                         </div>
-
 
                         <div id="formPlacementBarCon"><label>Form slides out from</label>
                             <div><input type="radio" name="formPlacementBar" class="styledRadio" id="formPlacementBarTop" value="top"<?php if ($formPlacementBar=="top") {echo " checked=\"checked\"";} ?> />

--- a/forms/views/admin/connect.php
+++ b/forms/views/admin/connect.php
@@ -271,7 +271,7 @@ function htmlDecodeEncode($str)
                                                 <span class="edit">
                                                     <a href="<?php echo get_admin_url(); ?>admin.php?page=campaign_monitor_create_builder&formId=<?php echo urlencode($currentFormId); ?>" aria-label="Edit Form">Edit</a>
                                                      | </span><span class="trash">
-                                                    <a href="<?php echo get_admin_url(); ?>admin.php?page=campaign_monitor_create_builder&formId=<?php echo urlencode($form->getId()); ?>&amp;action=delete" data-id="submitdelete_<?php echo filter_var($currentFormId, FILTER_SANITIZE_STRING); ?>" class="submitdelete" aria-label="Move “Cart” to the Trash">Trash</a><?php /* |
+                                                    <a href="<?php echo get_admin_url(); ?>admin.php?page=campaign_monitor_create_builder&formId=<?php echo urlencode($form->getId()); ?>&amp;action=delete" data-id="submitdelete_<?php echo htmlspecialchars($currentFormId); ?>" class="submitdelete" aria-label="Move “Cart” to the Trash">Trash</a><?php /* |
                                                 </span><span class="view"><a href="http://localhost/wp/cart/" rel="permalink" aria-label="View “Cart”">View</a>*/ ?>
                                                 </span></div><button type="button" class="toggle-row"><span class="screen-reader-text">Show more details</span></button></td>
                             <td class="status column-status" data-colname="Status"><?php

--- a/forms/views/admin/connect.php
+++ b/forms/views/admin/connect.php
@@ -4,6 +4,7 @@ use forms\core\Helper;
 use forms\core\Request;
 use forms\core\Settings;
 use forms\core\FormType;
+use forms\core\Security;
 
 
 $appSettings  = Settings::get();
@@ -271,7 +272,7 @@ function htmlDecodeEncode($str)
                                                 <span class="edit">
                                                     <a href="<?php echo get_admin_url(); ?>admin.php?page=campaign_monitor_create_builder&formId=<?php echo urlencode($currentFormId); ?>" aria-label="Edit Form">Edit</a>
                                                      | </span><span class="trash">
-                                                    <a href="<?php echo get_admin_url(); ?>admin.php?page=campaign_monitor_create_builder&formId=<?php echo urlencode($form->getId()); ?>&amp;action=delete" data-id="submitdelete_<?php echo htmlspecialchars($currentFormId); ?>" class="submitdelete" aria-label="Move “Cart” to the Trash">Trash</a><?php /* |
+                                                    <a href="<?php echo get_admin_url(); ?>admin.php?page=campaign_monitor_create_builder&formId=<?php echo urlencode($form->getId()); ?>&amp;action=delete" data-id="submitdelete_<?php echo Security::sanitize($currentFormId); ?>" class="submitdelete" aria-label="Move “Cart” to the Trash">Trash</a><?php /* |
                                                 </span><span class="view"><a href="http://localhost/wp/cart/" rel="permalink" aria-label="View “Cart”">View</a>*/ ?>
                                                 </span></div><button type="button" class="toggle-row"><span class="screen-reader-text">Show more details</span></button></td>
                             <td class="status column-status" data-colname="Status"><?php

--- a/forms/views/admin/settings.php
+++ b/forms/views/admin/settings.php
@@ -37,10 +37,10 @@ $notices = \forms\core\Request::get( 'notice' );
 if (!empty( $notices )) {
     $html = '<div id="message" class="notice-success notice is-dismissible">';
     $html .= '<h2>';
-    $html .= $notices['title'];
+    $html .= htmlspecialchars($notices['title']);
     $html .= '</h2>';
     $html .= '<p>';
-    $html .=  $notices['description'];
+    $html .=  htmlspecialchars($notices['description']);
     $html .= '</p>';
     $html .= '<button type="button" class="notice-dismiss"><span class="screen-reader-text">Dismiss this notice.</span></button>';
     $html .= '</div><!-- .updated -->';

--- a/forms/views/admin/settings.php
+++ b/forms/views/admin/settings.php
@@ -77,7 +77,7 @@ if (!empty( $notices )) {
                         <tbody><tr>
                             <th><label for="client_id">Client ID</label></th>
                             <td>
-                                <input type="text" class="regular-text" value="<?php echo filter_var($clientId, FILTER_SANITIZE_STRING); ?>" id="client_id" name="client_id" <?php echo $connected ? 'disabled' : ''?>>
+                                <input type="text" class="regular-text" value="<?php echo htmlspecialchars($clientId); ?>" id="client_id" name="client_id" <?php echo $connected ? 'disabled' : ''?>>
                                 <br>
                                 <span class="description"></span>
                             </td>
@@ -85,7 +85,7 @@ if (!empty( $notices )) {
                         <tr>
                             <th><label for="client_secrect">Client Secret</label></th>
                             <td>
-                                <input type="text" class="regular-text" value="<?php echo filter_var($clientSecret, FILTER_SANITIZE_STRING); ?>" id="client_secret" name="client_secret" <?php echo $connected ? 'disabled' : ''?>>
+                                <input type="text" class="regular-text" value="<?php echo htmlspecialchars($clientSecret); ?>" id="client_secret" name="client_secret" <?php echo $connected ? 'disabled' : ''?>>
                                 <br>
                                 <span class="description"></span>
                             </td>
@@ -93,7 +93,7 @@ if (!empty( $notices )) {
                         <tr>
                             <th><label for="client_secrect">Google ReCaptcha Site Key</label></th>
                             <td>
-                                <input type="text" class="regular-text" value="<?php echo filter_var($recaptchaPublic, FILTER_SANITIZE_STRING); ?>" id="recaptcha_public" name="recaptcha_public">
+                                <input type="text" class="regular-text" value="<?php echo htmlspecialchars($recaptchaPublic); ?>" id="recaptcha_public" name="recaptcha_public">
                                 <br>
                                 <span class="description">
 
@@ -102,7 +102,7 @@ if (!empty( $notices )) {
                         </tr>                            <tr>
                             <th><label for="client_secrect">Google ReCaptcha Secret Key</label></th>
                             <td>
-                                <input type="text" class="regular-text" value="<?php echo filter_var($recaptchaKey, FILTER_SANITIZE_STRING); ?>" id="recaptcha_key" name="recaptcha_key">
+                                <input type="text" class="regular-text" value="<?php echo htmlspecialchars($recaptchaKey); ?>" id="recaptcha_key" name="recaptcha_key">
                                 <br>
                                 <span class="description">
                                     reCAPTCHA is a free service that protects your site from spam and abuse.<br>

--- a/forms/views/admin/settings.php
+++ b/forms/views/admin/settings.php
@@ -4,6 +4,7 @@ use forms\core\Settings;
 use forms\core\Options;
 use forms\core\Helper;
 use forms\core\Translator;
+use forms\core\Security;
 
 //\forms\core\Application::update();
 
@@ -22,10 +23,10 @@ if (!empty($error)) {
 
     $html = '<div id="message" class="notice-error notice is-dismissible">';
     $html .= '<h2>';
-    $html .= $error['title'];
+    $html .= Security::sanitize($error['title']);
     $html .= '</h2>';
     $html .= '<p>';
-    $html .=  $error['description'];
+    $html .=  Security::sanitize($error['description']);
     $html .= '</p>';
     $html .= '<button type="button" class="notice-dismiss"><span class="screen-reader-text">Dismiss this notice.</span></button>';
     $html .= '</div><!-- .updated -->';
@@ -37,10 +38,10 @@ $notices = \forms\core\Request::get( 'notice' );
 if (!empty( $notices )) {
     $html = '<div id="message" class="notice-success notice is-dismissible">';
     $html .= '<h2>';
-    $html .= htmlspecialchars($notices['title']);
+    $html .= Security::sanitize($notices['title']);
     $html .= '</h2>';
     $html .= '<p>';
-    $html .=  htmlspecialchars($notices['description']);
+    $html .=  Security::sanitize($notices['description']);
     $html .= '</p>';
     $html .= '<button type="button" class="notice-dismiss"><span class="screen-reader-text">Dismiss this notice.</span></button>';
     $html .= '</div><!-- .updated -->';
@@ -77,7 +78,7 @@ if (!empty( $notices )) {
                         <tbody><tr>
                             <th><label for="client_id">Client ID</label></th>
                             <td>
-                                <input type="text" class="regular-text" value="<?php echo htmlspecialchars($clientId); ?>" id="client_id" name="client_id" <?php echo $connected ? 'disabled' : ''?>>
+                                <input type="text" class="regular-text" value="<?php echo Security::sanitize($clientId); ?>" id="client_id" name="client_id" <?php echo $connected ? 'disabled' : ''?>>
                                 <br>
                                 <span class="description"></span>
                             </td>
@@ -85,7 +86,7 @@ if (!empty( $notices )) {
                         <tr>
                             <th><label for="client_secrect">Client Secret</label></th>
                             <td>
-                                <input type="text" class="regular-text" value="<?php echo htmlspecialchars($clientSecret); ?>" id="client_secret" name="client_secret" <?php echo $connected ? 'disabled' : ''?>>
+                                <input type="text" class="regular-text" value="<?php echo Security::sanitize($clientSecret); ?>" id="client_secret" name="client_secret" <?php echo $connected ? 'disabled' : ''?>>
                                 <br>
                                 <span class="description"></span>
                             </td>
@@ -93,7 +94,7 @@ if (!empty( $notices )) {
                         <tr>
                             <th><label for="client_secrect">Google ReCaptcha Site Key</label></th>
                             <td>
-                                <input type="text" class="regular-text" value="<?php echo htmlspecialchars($recaptchaPublic); ?>" id="recaptcha_public" name="recaptcha_public">
+                                <input type="text" class="regular-text" value="<?php echo Security::sanitize($recaptchaPublic); ?>" id="recaptcha_public" name="recaptcha_public">
                                 <br>
                                 <span class="description">
 
@@ -102,7 +103,7 @@ if (!empty( $notices )) {
                         </tr>                            <tr>
                             <th><label for="client_secrect">Google ReCaptcha Secret Key</label></th>
                             <td>
-                                <input type="text" class="regular-text" value="<?php echo htmlspecialchars($recaptchaKey); ?>" id="recaptcha_key" name="recaptcha_key">
+                                <input type="text" class="regular-text" value="<?php echo Security::sanitize($recaptchaKey); ?>" id="recaptcha_key" name="recaptcha_key">
                                 <br>
                                 <span class="description">
                                     reCAPTCHA is a free service that protects your site from spam and abuse.<br>

--- a/forms/views/public/formLayout.php
+++ b/forms/views/public/formLayout.php
@@ -207,7 +207,7 @@ if (!is_null($form))
 
     $boxBgStyle = "";
     if (!empty($backgroundColorHex) && $formType !== 'embedded') {
-        $boxBgStyle = "background-color:#" . str_replace("#", "", filter_var($backgroundColorHex, FILTER_SANITIZE_STRING));
+        $boxBgStyle = "background-color:#" . str_replace("#", "", htmlspecialchars($backgroundColorHex));
     }
 
     $submitButtonText = $form->getSubmitButtonText();
@@ -296,17 +296,17 @@ if (!is_null($form))
 
     ?>
     <div id="cmApp_modalBackground" class="cmApp_hidden"></div>
-    <div class="cmApp_signupContainer <?php echo $hasSubHeader?> cmApp_<?php echo filter_var($formType, FILTER_SANITIZE_STRING) ?> cmApp_hidden<?php echo $placementCssClasses; ?>" id="cmApp_signupContainer" style="<?php echo $boxBgStyle; ?>">
+    <div class="cmApp_signupContainer <?php echo $hasSubHeader?> cmApp_<?php echo htmlspecialchars($formType) ?> cmApp_hidden<?php echo $placementCssClasses; ?>" id="cmApp_signupContainer" style="<?php echo $boxBgStyle; ?>">
         <?php if ($formType !== 'embedded'): ?>
             <a class="cmApp_closeFormButton"></a>
         <?php endif; ?>
         <div class="cmApp_signupFormWrapper">
             <?php if ($formType == 'slideoutTab') { ?>
-                <div class="cmApp_slideOutTab" style="background-color:<?php echo filter_var($buttonColorHex, FILTER_SANITIZE_STRING); ?>;">
-                    <a href="javascript:void(0);" id="cmApp_slideoutButton" style="color:<?php echo filter_var($buttonTextColorHex, FILTER_SANITIZE_STRING); ?>;"><?php _e(htmlDecodeEncode($submitButtonText)); ?></a>
+                <div class="cmApp_slideOutTab" style="background-color:<?php echo htmlspecialchars($buttonColorHex); ?>;">
+                    <a href="javascript:void(0);" id="cmApp_slideoutButton" style="color:<?php echo htmlspecialchars($buttonTextColorHex); ?>;"><?php _e(htmlDecodeEncode($submitButtonText)); ?></a>
                 </div>
             <?php } ?>
-            <input type="hidden" id="cmApp_formType" value="<?php echo filter_var($formType, FILTER_SANITIZE_STRING); ?>" />
+            <input type="hidden" id="cmApp_formType" value="<?php echo htmlspecialchars($formType); ?>" />
             <?php
             if (!empty($lightboxSeconds))        { ?><input type="hidden" id="lightboxSeconds" value="<?php echo intval($lightboxSeconds) ?>" /><?php }
             if (!empty($lightboxScrollPercent))  { ?><input type="hidden" id="lightboxScrollPercent" value="<?php echo intval($lightboxScrollPercent) ?>" /><?php }
@@ -333,10 +333,10 @@ if (!is_null($form))
                 <?php
                 if (!empty($formHeader)) { ?>
                     <div class="cmApp_formHeader"
-                         style="color:<?php echo filter_var($textHexColor, FILTER_SANITIZE_STRING); ?>"><?php _e(htmlDecodeEncode($formHeader)); ?></div><?php }
+                         style="color:<?php echo htmlspecialchars($textHexColor); ?>"><?php _e(htmlDecodeEncode($formHeader)); ?></div><?php }
                 if (!empty($formSubHeader) && $formType !== 'bar') { ?>
                     <div class="cmApp_formSubHeader"
-                         style="color:<?php echo filter_var($textHexColor, FILTER_SANITIZE_STRING); ?>"><?php _e(htmlDecodeEncode($formSubHeader)); ?></div><?php }
+                         style="color:<?php echo htmlspecialchars($textHexColor); ?>"><?php _e(htmlDecodeEncode($formSubHeader)); ?></div><?php }
                 ?>
 
                 <div class="cmApp_errorMsg" id="cmApp_errorAll"></div>
@@ -390,14 +390,14 @@ if (!is_null($form))
                         <div class="cmApp_signupGenderFields cmApp_cf cmApp_formInput">
                             <div class="cmApp_signupGenderFieldsContainer cmApp_cf">
                                 <input type="radio" name="gender" value="male" id="cmApp_radioMale" class="cmApp_styledRadio">
-                                <label for="cmApp_radioMale" style="color:<?php echo filter_var($textHexColor, FILTER_SANITIZE_STRING); ?>">
+                                <label for="cmApp_radioMale" style="color:<?php echo htmlspecialchars($textHexColor); ?>">
                                         <span>
                                             <span></span>
                                         </span>
                                     Male
                                 </label>
                                 <input type="radio" name="gender" value="female" class="cmApp_styledRadio" id="cmApp_radioFemale">
-                                <label for="cmApp_radioFemale" style="color:<?php echo filter_var($textHexColor, FILTER_SANITIZE_STRING); ?>">
+                                <label for="cmApp_radioFemale" style="color:<?php echo htmlspecialchars($textHexColor); ?>">
                                         <span style="margin-left: 10px;">
                                             <span></span>
                                         </span>
@@ -433,7 +433,7 @@ if (!is_null($form))
                 <div>
                     <input type="submit" name="submit" value="<?php echo _e(htmlDecodeEncode($submitButtonText)); ?>"
                            class="cmApp_formSubmitButton post-ajax"
-                           style="background-color:<?php echo filter_var($buttonColorHex, FILTER_SANITIZE_STRING); ?>; color:<?php echo filter_var($buttonTextColorHex, FILTER_SANITIZE_STRING); ?>;" data-submit="">
+                           style="background-color:<?php echo htmlspecialchars($buttonColorHex); ?>; color:<?php echo htmlspecialchars($buttonTextColorHex); ?>;" data-submit="">
                 </div>
 
                 <?php if (!empty($hasCampMonLogo)) { ?>
@@ -884,7 +884,7 @@ if (!is_null($form))
             font-size: 16px;
             font-weight: normal;
             display: none;
-            color: <?php echo filter_var($textHexColor, FILTER_SANITIZE_STRING); ?>;
+            color: <?php echo htmlspecialchars($textHexColor); ?>;
         }
 
         .cmApp_signupContainer div.cmApp_errorMsg {
@@ -1002,7 +1002,7 @@ if (!is_null($form))
             font-size: 14px;
             font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
             font-weight: 400;
-            color: <?php echo filter_var($textHexColor, FILTER_SANITIZE_STRING); ?>;
+            color: <?php echo htmlspecialchars($textHexColor); ?>;
             /*float: left;*/
             margin-left: 5px;
         }
@@ -1099,7 +1099,7 @@ if (!is_null($form))
 
         .cmApp_styledRadio:checked + label span:nth-child(1) span {
 
-            background: <?php echo filter_var($buttonColorHex, FILTER_SANITIZE_STRING); ?>;
+            background: <?php echo htmlspecialchars($buttonColorHex); ?>;
             -webkit-transition: background-color 100ms linear, -webkit-transform 100ms linear;
             -moz-transition: background-color 100ms linear, -moz-transform 100ms linear;
             -o-transition: background-color 100ms linear, -o-transform 100ms linear;

--- a/forms/views/public/formLayout.php
+++ b/forms/views/public/formLayout.php
@@ -1,10 +1,6 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: SunriseIntegration5
- * Date: 11/14/2016
- * Time: 10:46 AM
- */
+
+use \forms\core\Security;
 
 $pageId=get_the_ID();
 $campaignMonitorViewedIds = "";
@@ -207,7 +203,7 @@ if (!is_null($form))
 
     $boxBgStyle = "";
     if (!empty($backgroundColorHex) && $formType !== 'embedded') {
-        $boxBgStyle = "background-color:#" . str_replace("#", "", htmlspecialchars($backgroundColorHex));
+        $boxBgStyle = "background-color:#" . str_replace("#", "", Security::sanitize($backgroundColorHex));
     }
 
     $submitButtonText = $form->getSubmitButtonText();
@@ -302,11 +298,11 @@ if (!is_null($form))
         <?php endif; ?>
         <div class="cmApp_signupFormWrapper">
             <?php if ($formType == 'slideoutTab') { ?>
-                <div class="cmApp_slideOutTab" style="background-color:<?php echo htmlspecialchars($buttonColorHex); ?>;">
-                    <a href="javascript:void(0);" id="cmApp_slideoutButton" style="color:<?php echo htmlspecialchars($buttonTextColorHex); ?>;"><?php _e(htmlDecodeEncode($submitButtonText)); ?></a>
+                <div class="cmApp_slideOutTab" style="background-color:<?php echo Security::sanitize($buttonColorHex); ?>;">
+                    <a href="javascript:void(0);" id="cmApp_slideoutButton" style="color:<?php echo Security::sanitize($buttonTextColorHex); ?>;"><?php _e(htmlDecodeEncode($submitButtonText)); ?></a>
                 </div>
             <?php } ?>
-            <input type="hidden" id="cmApp_formType" value="<?php echo htmlspecialchars($formType); ?>" />
+            <input type="hidden" id="cmApp_formType" value="<?php echo Security::sanitize($formType); ?>" />
             <?php
             if (!empty($lightboxSeconds))        { ?><input type="hidden" id="lightboxSeconds" value="<?php echo intval($lightboxSeconds) ?>" /><?php }
             if (!empty($lightboxScrollPercent))  { ?><input type="hidden" id="lightboxScrollPercent" value="<?php echo intval($lightboxScrollPercent) ?>" /><?php }
@@ -333,10 +329,10 @@ if (!is_null($form))
                 <?php
                 if (!empty($formHeader)) { ?>
                     <div class="cmApp_formHeader"
-                         style="color:<?php echo htmlspecialchars($textHexColor); ?>"><?php _e(htmlDecodeEncode($formHeader)); ?></div><?php }
+                         style="color:<?php echo Security::sanitize($textHexColor); ?>"><?php _e(htmlDecodeEncode($formHeader)); ?></div><?php }
                 if (!empty($formSubHeader) && $formType !== 'bar') { ?>
                     <div class="cmApp_formSubHeader"
-                         style="color:<?php echo htmlspecialchars($textHexColor); ?>"><?php _e(htmlDecodeEncode($formSubHeader)); ?></div><?php }
+                         style="color:<?php echo Security::sanitize($textHexColor); ?>"><?php _e(htmlDecodeEncode($formSubHeader)); ?></div><?php }
                 ?>
 
                 <div class="cmApp_errorMsg" id="cmApp_errorAll"></div>
@@ -397,7 +393,7 @@ if (!is_null($form))
                                     Male
                                 </label>
                                 <input type="radio" name="gender" value="female" class="cmApp_styledRadio" id="cmApp_radioFemale">
-                                <label for="cmApp_radioFemale" style="color:<?php echo htmlspecialchars($textHexColor); ?>">
+                                <label for="cmApp_radioFemale" style="color:<?php echo Security::sanitize($textHexColor); ?>">
                                         <span style="margin-left: 10px;">
                                             <span></span>
                                         </span>
@@ -433,7 +429,7 @@ if (!is_null($form))
                 <div>
                     <input type="submit" name="submit" value="<?php echo _e(htmlDecodeEncode($submitButtonText)); ?>"
                            class="cmApp_formSubmitButton post-ajax"
-                           style="background-color:<?php echo htmlspecialchars($buttonColorHex); ?>; color:<?php echo htmlspecialchars($buttonTextColorHex); ?>;" data-submit="">
+                           style="background-color:<?php echo Security::sanitize($buttonColorHex); ?>; color:<?php echo Security::sanitize($buttonTextColorHex); ?>;" data-submit="">
                 </div>
 
                 <?php if (!empty($hasCampMonLogo)) { ?>
@@ -884,7 +880,7 @@ if (!is_null($form))
             font-size: 16px;
             font-weight: normal;
             display: none;
-            color: <?php echo htmlspecialchars($textHexColor); ?>;
+            color: <?php echo Security::sanitize($textHexColor); ?>;
         }
 
         .cmApp_signupContainer div.cmApp_errorMsg {
@@ -1002,7 +998,7 @@ if (!is_null($form))
             font-size: 14px;
             font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
             font-weight: 400;
-            color: <?php echo htmlspecialchars($textHexColor); ?>;
+            color: <?php echo Security::sanitize($textHexColor); ?>;
             /*float: left;*/
             margin-left: 5px;
         }
@@ -1099,7 +1095,7 @@ if (!is_null($form))
 
         .cmApp_styledRadio:checked + label span:nth-child(1) span {
 
-            background: <?php echo htmlspecialchars($buttonColorHex); ?>;
+            background: <?php echo Security::sanitize($buttonColorHex); ?>;
             -webkit-transition: background-color 100ms linear, -webkit-transform 100ms linear;
             -moz-transition: background-color 100ms linear, -moz-transform 100ms linear;
             -o-transition: background-color 100ms linear, -o-transform 100ms linear;
@@ -1206,7 +1202,7 @@ if (!is_null($form))
         ?>
         <script>
 
-        cmApp_signup_writeCookie("campaignMonitorViewedIds", "<?php echo htmlspecialchars($updatedCampaignMonitorViewedIds); ?>");
+        cmApp_signup_writeCookie("campaignMonitorViewedIds", "<?php echo Security::sanitize($updatedCampaignMonitorViewedIds); ?>");
     </script>
         <?php
     }

--- a/forms/views/public/recaptcha.php
+++ b/forms/views/public/recaptcha.php
@@ -1,6 +1,6 @@
 
 
-<div class="g-recaptcha" data-sitekey="<?php echo filter_var($this->getSitePublic(), FILTER_SANITIZE_STRING); ?>"></div>
+<div class="g-recaptcha" data-sitekey="<?php echo htmlspecialchars($this->getSitePublic()); ?>"></div>
 <script type="text/javascript"
-        src="https://www.google.com/recaptcha/api.js?hl=<?php echo filter_var($this->getLang(), FILTER_SANITIZE_STRING); ?>">
+        src="https://www.google.com/recaptcha/api.js?hl=<?php echo htmlspecialchars($this->getLang()); ?>">
 </script>

--- a/forms/views/public/recaptcha.php
+++ b/forms/views/public/recaptcha.php
@@ -2,5 +2,5 @@
 
 <div class="g-recaptcha" data-sitekey="<?php echo htmlspecialchars($this->getSitePublic()); ?>"></div>
 <script type="text/javascript"
-        src="https://www.google.com/recaptcha/api.js?hl=<?php echo htmlspecialchars($this->getLang()); ?>">
+        src="https://www.google.com/recaptcha/api.js?hl=<?php echo htmlspecialchars($this->getLang(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, 'UTF-8'); ?>">
 </script>

--- a/forms/views/templates/webfont.php
+++ b/forms/views/templates/webfont.php
@@ -9,7 +9,7 @@
   <script> 
         WebFont.load({
                     google: { 
-                           families: ['<?php echo htmlspecialchars($this->getName()); ?>'] 
+                           families: ['<?php echo htmlspecialchars($this->getName(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, 'UTF-8'); ?>'] 
                      } 
          }); 
    </script>
@@ -17,6 +17,6 @@
     #cmApp_signupContainer *,
     #signupFormPreviewCon *,
     .cmApp_signupContainer.cmApp_slideoutTab .cmApp_slideOutTab #cmApp_slideoutButton {
-        font-family : '<?php echo htmlspecialchars($this->getName()); ?>';
+        font-family : '<?php echo htmlspecialchars($this->getName(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, 'UTF-8'); ?>';
     }
    </style>

--- a/forms/views/templates/webfont.php
+++ b/forms/views/templates/webfont.php
@@ -9,7 +9,7 @@
   <script> 
         WebFont.load({
                     google: { 
-                           families: ['<?php echo filter_var($this->getName(), FILTER_SANITIZE_STRING); ?>'] 
+                           families: ['<?php echo htmlspecialchars($this->getName()); ?>'] 
                      } 
          }); 
    </script>
@@ -17,6 +17,6 @@
     #cmApp_signupContainer *,
     #signupFormPreviewCon *,
     .cmApp_signupContainer.cmApp_slideoutTab .cmApp_slideOutTab #cmApp_slideoutButton {
-        font-family : '<?php echo filter_var($this->getName(), FILTER_SANITIZE_STRING); ?>';
+        font-family : '<?php echo htmlspecialchars($this->getName()); ?>';
     }
    </style>


### PR DESCRIPTION
- [`FILTER_SANITIZE_STRING`](https://www.php.net/manual/en/filter.filters.sanitize.php) is deprecated as of PHP 8.0.1. Switch to using [`htmlspecialchars`](https://www.php.net/manual/en/function.htmlspecialchars.php) instead (which is compatible with older PHP versions).
- Use `ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401` as the flags for `htmlspecialchars` to ensure the same behaviour pre & post PHP 8.1.0.
- Add sanitisation to a couple of places where GET data was rendered as HTML.
- Use `Security::sanitize` wherever possible to ensure we're consistent with flags & encoding.