### PR TITLE
COMP-617: Version 2.8.18, Wordpress 6.8 support

### DIFF
--- a/campaign-monitor.php
+++ b/campaign-monitor.php
@@ -5,7 +5,7 @@ defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
  * Plugin Name: Campaign Monitor for WordPress
  * Plugin URI: http://campaignmonitor.com
  * Description: Manage Campaign Monitor Lists, Custom Fields and add forms and how you show them to your users..
- * Version: 2.8.17
+ * Version: 2.8.18
  * Author: Campaign Monitor
  * Author URI: http://campaignmonitor.com
  * License: License: GPLv2 or later

--- a/forms/views/public/js/app.js
+++ b/forms/views/public/js/app.js
@@ -541,7 +541,7 @@ isJqueryReady(function($jqueryInstance) {
             lightboxFieldElem.find("input").css("margin-left",0).css("margin-right",0);
         };
 
-        $jqueryInstance(window).on('load', function () {
+        $jqueryInstance(function () {
             $jqueryInstance(document).on('click', '.post-ajax', function (e) {
                 e.preventDefault();
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Donate link: N/A
 Tags: Campaign Monitor, Email Marketing, Sign-Up Forms, Sign Up Forms
 Requires at least: 3.9
 Requires PHP: 5.3
-Tested up to: 6.6
-Stable tag: 2.8.17
+Tested up to: 6.8
+Stable tag: 2.8.18
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -62,6 +62,10 @@ When we launched 2.0, we improved how our plugin saves forms in the WordPress da
 7. Easy to add a new form. Just select the form type, choose the Campaign Monitor List where  data will be collected, and you are done.
 
 == Changelog ==
+= 2.8.18 =
+* Support for Wordpress 6.8
+* Fix a legacy bug where the slideout form occasionally failed to respond/pop up when click subscribe btn
+
 = 2.8.17 =
 * Fix Minor issue
 


### PR DESCRIPTION
This update addresses a legacy bug where the slideout form intermittently failed to appear when clicking the subscribe button. The issue was caused by relying on the window.load event, which doesn't consistently fire across all setups. The initialization logic has been updated to use the DOM ready event ($jqueryInstance(function () { ... })) to ensure reliable execution once the DOM is fully loaded. Additionally, plugin metadata has been updated:

Version bumped from 2.8.17 to 2.8.18

Tested up to updated to WordPress 6.8

Changelog section updated in readme.txt